### PR TITLE
fix: adjust background color for dark mode

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -14,6 +14,7 @@ $global-transition: all 0.2s ease-in-out;
   --text-color: #2D3748;
   --border-color: #CBD5E0;
   --code-background-color: #F7FAFC;
+  --background-color: #FFFFFF;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -24,6 +25,7 @@ $global-transition: all 0.2s ease-in-out;
     --text-color: #E2E8F0;
     --border-color: #4A5568;
     --code-background-color: #2D3748;
+    --background-color: #2D3748;
   }
 }
 

--- a/_sass/_reset.scss
+++ b/_sass/_reset.scss
@@ -7,7 +7,7 @@
 html {
   /* apply a natural box layout model to all elements */
   box-sizing: border-box;
-  background-color: $background-color;
+  background-color: var(--background-color);
   font-size: 15px;
 
   // @include breakpoint($medium) {


### PR DESCRIPTION
## Summary
- add background-color CSS variable with dark-mode value
- apply background-color variable to html element

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68aab7ed24c083209e47d6746faa605e