### PR TITLE
Improve homepage styling and add citation updater

### DIFF
--- a/_data/google_scholar_stats.json
+++ b/_data/google_scholar_stats.json
@@ -1,0 +1,4 @@
+{
+  "citedby": 0,
+  "updated": ""
+}

--- a/_pages/includes/intro.md
+++ b/_pages/includes/intro.md
@@ -1,5 +1,7 @@
 I currently study in [KAIST EE](https://ee.kaist.ac.kr/en/) as a PhD student. ([Short CV](https://flowcv.com/resume/0sg7gc7cdl))
 
+According to [Google Scholar](https://scholar.google.com/citations?user=4Yr_icEAAAAJ), I have {{ site.data.google_scholar_stats.citedby }} citations.
+
 From March 2023, I work at [Multimodal AI Lab](https://mmai.io/) under the supervision of [Prof. Joon Son Chung](https://mmai.io/joon/).
 
 I am now working on speech/audio synthesis, and interest in multimodal generative models. If you are seeking any form of **academic cooperation**, please feel free to email me at [tandat.kaist@kaist.ac.kr](mailto:tandat.kaist@kaist.ac.kr).

--- a/_pages/includes/others.md
+++ b/_pages/includes/others.md
@@ -5,11 +5,11 @@
 - *2018.10 - 2022.10*, Undergraduate, Ho Chi Minh University of Technology - Vietnam National University. Ho Chi Minh city, Vietnam. (Thesis grade: 9.8/10)
 - *2015.08 - 2018.08*, Nguyen Chi Thanh high school for gifted. Dak Nong, Vietnam
 
-<!-- # 💬 Invited Talks
+# 💬 Invited Talks
 - *2022.02*, Hosted MLNLP seminar \| [\[Video\]](https://www.bilibili.com/video/BV1wF411x7qh)
 - *2021.06*, Audio & Speech Synthesis, Huawei internal talk
 - *2021.03*, Non-autoregressive Speech Synthesis, PaperWeekly & biendata \| [\[video\]](https://www.bilibili.com/video/BV1uf4y1t7Hr/)
-- *2020.12*, Non-autoregressive Speech Synthesis, Huawei Noah's Ark Lab internal talk -->
+- *2020.12*, Non-autoregressive Speech Synthesis, Huawei Noah's Ark Lab internal talk
 
 # 💻 Internships
 - *2021.06 - 2021.09*, OLLI Technology Corp., Vietnam.

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -50,24 +50,24 @@ $type-size-8                : 0.625em;  // ~10px
    Colors
    ========================================================================== */
 
-$gray                       : #7a8288;
+$gray                       : #6c757d;
 $dark-gray                  : mix(#000, $gray, 40%);
 $darker-gray                : mix(#000, $gray, 60%);
 $light-gray                 : mix(#fff, $gray, 50%);
 $lighter-gray               : mix(#fff, $gray, 90%);
 
-$body-color                 : #fff;
-$background-color           : #fff;
+$body-color                 : #f9fafb;
+$background-color           : #f9fafb;
 $code-background-color      : #fafafa;
 $code-background-color-dark : $light-gray;
 $text-color                 : $dark-gray;
 $border-color               : $lighter-gray;
 
-$primary-color              : #7a8288;
+$primary-color              : #4a90e2;
 $success-color              : #62c462;
 $warning-color              : #f89406;
 $danger-color               : #ee5f5b;
-$info-color                 : #224b8d;
+$info-color                 : #4a90e2;
 // $info-color                 : #52adc8;
 
 /* brands */

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -59,6 +59,7 @@
             max-width: 400px;
             box-shadow: 3px 3px 6px #888;
             object-fit: cover;
+            border-radius: 8px;
         }
     }
     
@@ -104,6 +105,6 @@ h1:before, .anchor:before {
     margin-top: .5em;
     margin-left: -.5em;
     color: white;
-    background-color: #007bff;
+    background-color: $primary-color;
     font-size: .8em;
 }

--- a/google_scholar_crawler/main.py
+++ b/google_scholar_crawler/main.py
@@ -3,6 +3,7 @@ import jsonpickle
 import json
 from datetime import datetime
 import os
+from pathlib import Path
 
 author: dict = scholarly.search_author_id(os.environ['GOOGLE_SCHOLAR_ID'])
 scholarly.fill(author, sections=['basics', 'indices', 'counts', 'publications'])
@@ -22,3 +23,9 @@ shieldio_data = {
 
 with open(f'results/gs_data_shieldsio.json', 'w') as outfile:
     json.dump(shieldio_data, outfile, ensure_ascii=False)
+
+repo_root = Path(__file__).resolve().parent.parent
+data_dir = repo_root / "_data"
+data_dir.mkdir(exist_ok=True)
+with open(data_dir / "google_scholar_stats.json", 'w') as outfile:
+    json.dump({"citedby": author['citedby'], "updated": author['updated']}, outfile, ensure_ascii=False)


### PR DESCRIPTION
## Summary
- Fix Invited Talks link to jump to on-page section
- Refresh color palette and round paper thumbnails
- Display Google Scholar citation count via updatable script

## Testing
- `python -m py_compile google_scholar_crawler/main.py`
- `GOOGLE_SCHOLAR_ID=4Yr_icEAAAAJ python google_scholar_crawler/main.py` *(fails: MaxTriesExceededException: Cannot Fetch from Google Scholar.)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden" during bundle install)*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68abecccfc5c83208401ee5b259eed72