### PR TITLE
Fix profile update and scholar workflows

### DIFF
--- a/.github/workflows/google_scholar_crawler.yaml
+++ b/.github/workflows/google_scholar_crawler.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install Reqs
       run: |
-        sudo apt-get install python3-setuptools
+        sudo apt-get install -y python3-setuptools
     - name: Run
       run: |
         cd ./google_scholar_crawler
@@ -21,6 +21,7 @@ jobs:
         cd ./results
         git init
         git config --local user.name "${GITHUB_ACTOR}"
+        git config --local user.email "tandat.kaist@kaist.ac.kr"
         export remote_repo="https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
         git add *.json
         git commit -m "Updated Citation Data"

--- a/.github/workflows/update_github_myprofile.yaml
+++ b/.github/workflows/update_github_myprofile.yaml
@@ -8,15 +8,15 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install Reqs
       run: |
-        sudo apt-get install python3-setuptools
+        sudo apt-get install -y python3-setuptools
     - name: Run
       run: |
         cd ./github_myprofile_updater
         python3 update.py
         git init
         git config --local user.name "${GITHUB_ACTOR}"
-        git config --local user.email "rayeren613@gmail.com"
-        export remote_repo="https://${GITHUB_ACTOR}:${{ secrets.GHRS_GITHUB_API_TOKEN }}@github.com/RayeRen/RayeRen.git"
+        git config --local user.email "tandat.kaist@kaist.ac.kr"
+        export remote_repo="https://${GITHUB_ACTOR}:${{ secrets.GHRS_GITHUB_API_TOKEN }}@github.com/${GITHUB_ACTOR}/${GITHUB_ACTOR}.git"
         git add README.md
         git add images
         git commit -m "update my description automatically"


### PR DESCRIPTION
## Summary
- use new email and remote repo for profile updater
- configure email and noninteractive installs for Google Scholar stats workflow

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68abf32017c8832081b77e8fa0dd69ae