### PR TITLE
Style publication links as buttons

### DIFF
--- a/_pages/includes/pub.md
+++ b/_pages/includes/pub.md
@@ -1,5 +1,4 @@
-
-# 📝 Publications 
+# 📝 Publications
 ## 🎙 Speech Synthesis
 
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">ICASSP 2025</div><img src='images/accelerate.png' alt="sym" width="100%"></div></div>
@@ -8,10 +7,14 @@
 [**Accelerating Codec-based Speech Synthesis with Multi-Token Prediction and Speculative Decoding**](https://arxiv.org/abs/2410.13839)
 
 __Tan Dat Nguyen__* , [Ji-Hoon Kim](https://sites.google.com/view/jhoonkim/)*, [Jeongsoo Choi](https://choijeongsoo.github.io/), Shukjae Choi, Jinseok Park, Younglo Lee, [Joon Son Chung+](https://mmai.io/joon/)
-[**Demo page**](https://mm.kaist.ac.kr/projects/mtp/)
 
 - Proposes a method to accelerate codec-based speech synthesis by predicting multiple tokens per step and optimizing token selection with a Viterbi-based speculative decoding technique.
 - Achieves a 4-5x reduction in synthesis time with minimal or improved speech quality.
+
+<div class="paper-links">
+  <a class="btn" href="https://mm.kaist.ac.kr/projects/mtp/" target="_blank" rel="noopener">Demo page</a>
+  <a class="btn btn--info" href="https://arxiv.org/abs/2410.13839" target="_blank" rel="noopener">arXiv</a>
+</div>
 
 </div>
 </div>
@@ -22,11 +25,17 @@ __Tan Dat Nguyen__* , [Ji-Hoon Kim](https://sites.google.com/view/jhoonkim/)*, [
 [**FreGrad: Lightweight and fast frequency-aware diffusion vocoder**](https://arxiv.org/abs/2401.10032)
 
 __Tan Dat Nguyen__* , [Ji-Hoon Kim](https://sites.google.com/view/jhoonkim/)*, [Youngjoon Jang](https://art-jang.github.io/), [Jaehun Kim](https://smokedindia.notion.site/Jaehun-Kim-5006f1fc98004817885325241723f1e3?pvs=74), [Joon Son Chung+](https://mmai.io/joon/)
-[**Demo page**](https://mm.kaist.ac.kr/projects/FreGrad/), [**Official Code**](https://github.com/kaistmm/fregrad) (<font color="red"> Oral Presentation </font>)
+ (<font color="red"> Oral Presentation </font>)
 <!-- # ! This one has code for showing citation-->
 <!-- [**Project Page**](https://scholar.google.com/citations?view_op=view_citation&hl=zh-CN&user=DhtAFkwAAAAJ&citation_for_view=DhtAFkwAAAAJ:ALROH1vI_8AC) <strong><span class='show_paper_citations' data='DhtAFkwAAAAJ:ALROH1vI_8AC'></span></strong> -->
 - We employ discrete wavelet transform that helps FreGrad to operate on a simple and concise feature space.
 - We design a frequency-aware dilated convolution and introduce a bag of tricks that boosts the generation quality of the proposed model.
+
+<div class="paper-links">
+  <a class="btn" href="https://mm.kaist.ac.kr/projects/FreGrad/" target="_blank" rel="noopener">Demo page</a>
+  <a class="btn btn--info" href="https://arxiv.org/abs/2401.10032" target="_blank" rel="noopener">arXiv</a>
+  <a class="btn btn--success" href="https://github.com/kaistmm/fregrad" target="_blank" rel="noopener">Official Code</a>
+</div>
 
 </div>
 </div>
@@ -39,10 +48,13 @@ __Tan Dat Nguyen__* , [Ji-Hoon Kim](https://sites.google.com/view/jhoonkim/)*, [
 
 __Nguyen Tan Dat__, Lam Quang Tuong, Nguyen Duc Dung
 
-[**Demo page**](https://signofthefour.github.io/calib-stylespeech-demo/).
-
 - We propose to use CLUB to minimize the mutual information between content embedding and style embedding.
 - Our work well-perform on zero-shot scenerio even when using skew ASR dataset
+
+<div class="paper-links">
+  <a class="btn" href="https://signofthefour.github.io/calib-stylespeech-demo/" target="_blank" rel="noopener">Demo page</a>
+  <a class="btn btn--info" href="https://link.springer.com/chapter/10.1007/978-3-030-97610-1_6" target="_blank" rel="noopener">Paper</a>
+</div>
 
 </div>
 </div>
@@ -55,9 +67,13 @@ __Nguyen Tan Dat__, Lam Quang Tuong, Nguyen Duc Dung
 
 __Tan Dat Nguyen__, Quang Tuong Lam, Duc Hao Do, Huu Thuc Cai, Hoang Suong Nguyen, Thanh Hung Vo, Duc Dung Nguyen.
 
-[**Demo page**](https://signofthefour.github.io/bahnar_demo/).
-
 - We apply phonetic-based transfer learning approach to create Bahnar-Kriem (very low resource language) TTS model.
 
+<div class="paper-links">
+  <a class="btn" href="https://signofthefour.github.io/bahnar_demo/" target="_blank" rel="noopener">Demo page</a>
+  <a class="btn btn--info" href="https://ieeexplore.ieee.org/document/10013451" target="_blank" rel="noopener">Paper</a>
+</div>
+
 </div>
 </div>
+

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -135,6 +135,19 @@ $base-border-radius: 20px;
     margin-top: -1.5em;
     padding-left: 1.25rem;
   }
+
+  .paper-links {
+    margin-top: 0.75rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+
+    .btn {
+      margin-bottom: 0;
+      min-width: 7.5rem;
+      text-decoration: none;
+    }
+  }
 }
 
 .page__hero {


### PR DESCRIPTION
## Summary
- convert publication resource links into grouped buttons for each paper entry
- add layout styling for publication button groups to ensure consistent spacing

## Testing
- bundle exec jekyll build *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ef6490ac832086f233965ae8080a