### PR TITLE
Unify publications section and add resume link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,8 @@ author:
   bio              : "Researcher"
   location         : "Daejeon, Korea"
   employer         :
-  pubmed           : 
+  resume           : "https://flowcv.com/resume/0sg7gc7cdl"
+  pubmed           :
   googlescholar    : "https://scholar.google.com/citations?user=4Yr_icEAAAAJ&hl"
   email            : "tandat.kaist@kaist.ac.kr"
   researchgate     :  # example: "https://www.researchgate.net/profile/yourprofile"

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -28,6 +28,9 @@
       {% if author.uri %}
         <li><a href="{{ author.uri }}"><i class="fas fa-fw fa-link" aria-hidden="true"></i> Website</a></li>
       {% endif %}
+      {% if author.resume %}
+        <li><a href="{{ author.resume }}" target="_blank" rel="noopener"><i class="fas fa-fw fa-file-alt" aria-hidden="true"></i> Academic Resume</a></li>
+      {% endif %}
       {% if author.email %}
         <li><a href="mailto:{{ author.email }}"><i class="fas fa-fw fa-envelope" aria-hidden="true"></i> Email</a></li>
       {% endif %}
@@ -122,6 +125,9 @@
       <div class="author__urls_sm">
       {% if author.uri %}
         <a href="{{ author.uri }}"><i class="fas fa-fw fa-link" aria-hidden="true"></i></a>
+      {% endif %}
+      {% if author.resume %}
+        <a href="{{ author.resume }}" target="_blank" rel="noopener"><i class="fas fa-fw fa-file-alt" aria-hidden="true"></i></a>
       {% endif %}
       {% if author.email %}
         <a href="mailto:{{ author.email }}"><i class="fas fa-fw fa-envelope" aria-hidden="true"></i></a>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -15,8 +15,6 @@ redirect_from:
 
 {% include_relative includes/pub.md %}
 
-{% include_relative includes/pub_short.md %}
-
 {% include_relative includes/honers.md %}
 
 {% include_relative includes/others.md %}

--- a/_pages/includes/pub.md
+++ b/_pages/includes/pub.md
@@ -1,7 +1,80 @@
 # 📝 Publications
+
 ## 🎙 Speech Synthesis
 
-<div class='paper-box'><div class='paper-box-image'><div><div class="badge">ICASSP 2025</div><img src='images/accelerate.png' alt="sym" width="100%"></div></div>
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">ArXiv 2025</div><img src='images/500x300.png' alt="Placeholder cover for SPADE" width="100%"></div></div>
+<div class='paper-box-text' markdown="1">
+
+[**SPADE: Structured Pruning and Adaptive Distillation for Efficient LLM-TTS**](https://arxiv.org/abs/2509.20802v1)
+
+__Tan Dat Nguyen__, Jaehun Kim, Ji-Hoon Kim, Shukjae Choi, Youshin Lim, Joon Son Chung.
+
+- Introduces a joint structured pruning and adaptive distillation pipeline to accelerate LLM-based text-to-speech systems.
+- Delivers efficient speech synthesis while preserving naturalness through carefully aligned student-teacher objectives.
+
+<div class="paper-links">
+  <a class="btn" href="https://mm.kaist.ac.kr/projects/SPADE/" target="_blank" rel="noopener">Demo page</a>
+  <a class="btn btn--info" href="https://arxiv.org/abs/2509.20802v1" target="_blank" rel="noopener" aria-label="View paper on arXiv" title="View paper on arXiv"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
+</div>
+
+</div>
+</div>
+
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">ArXiv 2025</div><img src='images/500x300.png' alt="Placeholder cover for MAGE" width="100%"></div></div>
+<div class='paper-box-text' markdown="1">
+
+[**MAGE: A Coarse-to-Fine Speech Enhancer with Masked Generative Model**](https://openreview.net/pdf?id=ZEPSOsi63p)
+
+The Hieu Pham*, __Tan Dat Nguyen__*, Phuong Thanh Tran, Joon Son Chung, Duc Dung Nguyen.
+
+- Presents a masked generative enhancement model that progressively restores high-quality speech from noisy inputs.
+- Uses a coarse-to-fine generation strategy to improve intelligibility while maintaining computational efficiency.
+
+<div class="paper-links">
+  <a class="btn" href="https://hieugiaosu.github.io/MAGE/" target="_blank" rel="noopener">Live Demo</a>
+  <a class="btn btn--info" href="https://openreview.net/pdf?id=ZEPSOsi63p" target="_blank" rel="noopener" aria-label="View paper" title="View paper"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
+</div>
+
+</div>
+</div>
+
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">OpenReview 2024</div><img src='images/500x300.png' alt="Placeholder cover for Language-Agnostic Target Speaker Extraction" width="100%"></div></div>
+<div class='paper-box-text' markdown="1">
+
+[**Language-Agnostic Target Speaker Extraction with Zero-Shot Generalization to Low-Resource Languages**](https://openreview.net/pdf?id=ZEPSOsi63p)
+
+The Hieu Pham, __Nguyen Tan Dat__, Phuong Thanh Tran, Duc Dung Nguyen.
+
+- Explores a language-agnostic speaker extraction system capable of zero-shot transfer to low-resource languages.
+- Demonstrates strong robustness across multilingual benchmarks without language-specific tuning.
+
+<div class="paper-links">
+  <a class="btn" href="https://anonymous.4open.science/w/WHYV/" target="_blank" rel="noopener">Live Demo</a>
+  <a class="btn btn--info" href="https://openreview.net/pdf?id=ZEPSOsi63p" target="_blank" rel="noopener" aria-label="View paper" title="View paper"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
+</div>
+
+</div>
+</div>
+
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">ArXiv 2024</div><img src='images/500x300.png' alt="Placeholder cover for Wanna Hear Your Voice" width="100%"></div></div>
+<div class='paper-box-text' markdown="1">
+
+[**Wanna Hear Your Voice: Adaptive, Effective, and Language-Agnostic Approach in Voice Extraction**](https://arxiv.org/abs/2410.00527v1)
+
+The Hieu Pham, __Nguyen Tan Dat__, Phuong Thanh Tran, Duc Dung Nguyen.
+
+- Proposes an adaptive extraction pipeline that personalizes target voice retrieval across languages.
+- Highlights a versatile framework with strong zero-shot generalization backed by comprehensive ablations.
+
+<div class="paper-links">
+  <a class="btn" href="https://anonymous.4open.science/w/WHYV/" target="_blank" rel="noopener">Live Demo</a>
+  <a class="btn btn--info" href="https://arxiv.org/abs/2410.00527v1" target="_blank" rel="noopener" aria-label="View paper on arXiv" title="View paper on arXiv"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
+</div>
+
+</div>
+</div>
+
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">ICASSP 2025</div><img src='images/accelerate.png' alt="Accelerating codec-based speech synthesis illustration" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
 [**Accelerating Codec-based Speech Synthesis with Multi-Token Prediction and Speculative Decoding**](https://arxiv.org/abs/2410.13839)
@@ -13,35 +86,32 @@ __Tan Dat Nguyen__* , [Ji-Hoon Kim](https://sites.google.com/view/jhoonkim/)*, [
 
 <div class="paper-links">
   <a class="btn" href="https://mm.kaist.ac.kr/projects/mtp/" target="_blank" rel="noopener">Demo page</a>
-  <a class="btn btn--info" href="https://arxiv.org/abs/2410.13839" target="_blank" rel="noopener">arXiv</a>
+  <a class="btn btn--info" href="https://arxiv.org/abs/2410.13839" target="_blank" rel="noopener" aria-label="View paper on arXiv" title="View paper on arXiv"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
 </div>
 
 </div>
 </div>
 
-<div class='paper-box'><div class='paper-box-image'><div><div class="badge">ICASSP 2024</div><img src='images/500x300.png' alt="sym" width="100%"></div></div>
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">ICASSP 2024</div><img src='images/500x300.png' alt="FreGrad illustration placeholder" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
 [**FreGrad: Lightweight and fast frequency-aware diffusion vocoder**](https://arxiv.org/abs/2401.10032)
 
-__Tan Dat Nguyen__* , [Ji-Hoon Kim](https://sites.google.com/view/jhoonkim/)*, [Youngjoon Jang](https://art-jang.github.io/), [Jaehun Kim](https://smokedindia.notion.site/Jaehun-Kim-5006f1fc98004817885325241723f1e3?pvs=74), [Joon Son Chung+](https://mmai.io/joon/)
- (<font color="red"> Oral Presentation </font>)
-<!-- # ! This one has code for showing citation-->
-<!-- [**Project Page**](https://scholar.google.com/citations?view_op=view_citation&hl=zh-CN&user=DhtAFkwAAAAJ&citation_for_view=DhtAFkwAAAAJ:ALROH1vI_8AC) <strong><span class='show_paper_citations' data='DhtAFkwAAAAJ:ALROH1vI_8AC'></span></strong> -->
+__Tan Dat Nguyen__* , [Ji-Hoon Kim](https://sites.google.com/view/jhoonkim/)*, [Youngjoon Jang](https://art-jang.github.io/), [Jaehun Kim](https://smokedindia.notion.site/Jaehun-Kim-5006f1fc98004817885325241723f1e3?pvs=74), [Joon Son Chung+](https://mmai.io/joon/) (<font color="red"> Oral Presentation </font>)
+
 - We employ discrete wavelet transform that helps FreGrad to operate on a simple and concise feature space.
 - We design a frequency-aware dilated convolution and introduce a bag of tricks that boosts the generation quality of the proposed model.
 
 <div class="paper-links">
   <a class="btn" href="https://mm.kaist.ac.kr/projects/FreGrad/" target="_blank" rel="noopener">Demo page</a>
-  <a class="btn btn--info" href="https://arxiv.org/abs/2401.10032" target="_blank" rel="noopener">arXiv</a>
-  <a class="btn btn--success" href="https://github.com/kaistmm/fregrad" target="_blank" rel="noopener">Official Code</a>
+  <a class="btn btn--info" href="https://arxiv.org/abs/2401.10032" target="_blank" rel="noopener" aria-label="View paper on arXiv" title="View paper on arXiv"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
+  <a class="btn btn--success" href="https://github.com/kaistmm/fregrad" target="_blank" rel="noopener" aria-label="View source on GitHub" title="View source on GitHub"><i class="fab fa-github" aria-hidden="true"></i></a>
 </div>
 
 </div>
 </div>
 
-
-<div class='paper-box'><div class='paper-box-image'><div><div class="badge">ICABDE 2021</div><img src='images/CalibStyelSpeech.png' alt="sym" width="100%"></div></div>
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">ICABDE 2021</div><img src='images/CalibStyelSpeech.png' alt="Calib-StyleSpeech illustration" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
 [**Calib-StyleSpeech: A Zero-shot Approach In Voice Cloning Of High Adaptive Text To Speech System With Imbalanced Dataset**](https://link.springer.com/chapter/10.1007/978-3-030-97610-1_6) (<font color="red"> Oral Presentation </font>)
@@ -53,14 +123,13 @@ __Nguyen Tan Dat__, Lam Quang Tuong, Nguyen Duc Dung
 
 <div class="paper-links">
   <a class="btn" href="https://signofthefour.github.io/calib-stylespeech-demo/" target="_blank" rel="noopener">Demo page</a>
-  <a class="btn btn--info" href="https://link.springer.com/chapter/10.1007/978-3-030-97610-1_6" target="_blank" rel="noopener">Paper</a>
+  <a class="btn btn--info" href="https://link.springer.com/chapter/10.1007/978-3-030-97610-1_6" target="_blank" rel="noopener" aria-label="View paper" title="View paper"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
 </div>
 
 </div>
 </div>
 
-
-<div class='paper-box'><div class='paper-box-image'><div><div class="badge">NAFOSTED 2021</div><img src='images/bahnar.png' alt="sym" width="100%"></div></div>
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">NAFOSTED 2021</div><img src='images/bahnar.png' alt="Bahnar TTS illustration" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
 [*A Linguistic-based Transfer Learning Approach for Low-resource Bahnar Text-to-Speech*](https://ieeexplore.ieee.org/document/10013451) (<font color="red"> Oral Presentation </font>)
@@ -71,9 +140,100 @@ __Tan Dat Nguyen__, Quang Tuong Lam, Duc Hao Do, Huu Thuc Cai, Hoang Suong Nguye
 
 <div class="paper-links">
   <a class="btn" href="https://signofthefour.github.io/bahnar_demo/" target="_blank" rel="noopener">Demo page</a>
-  <a class="btn btn--info" href="https://ieeexplore.ieee.org/document/10013451" target="_blank" rel="noopener">Paper</a>
+  <a class="btn btn--info" href="https://ieeexplore.ieee.org/document/10013451" target="_blank" rel="noopener" aria-label="View paper" title="View paper"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
 </div>
 
 </div>
 </div>
 
+## 🔬 Other Research Papers
+
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">ICASSP 2025</div><img src='images/500x300.png' alt="Placeholder cover for AdaptVC" width="100%"></div></div>
+<div class='paper-box-text' markdown="1">
+
+[**AdaptVC: High Quality Voice Conversion with Adaptive Learning**](https://arxiv.org/abs/2501.01347)
+
+Jaehun Kim, Ji-Hoon Kim, Yeunju Choi, __Tan Dat Nguyen__, Seongkyu Mun, Joon Son Chung.
+
+- Investigates adaptive learning strategies for high-fidelity voice conversion in cross-speaker scenarios.
+- Extended project assets are under preparation.
+
+<div class="paper-links">
+  <span class="btn disabled" role="button" aria-disabled="true">Demo coming soon</span>
+  <a class="btn btn--info" href="https://arxiv.org/abs/2501.01347" target="_blank" rel="noopener" aria-label="View paper on arXiv" title="View paper on arXiv"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
+</div>
+
+</div>
+</div>
+
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">ICASSP 2025</div><img src='images/500x300.png' alt="Placeholder cover for VoiceDiT" width="100%"></div></div>
+<div class='paper-box-text' markdown="1">
+
+[**VoiceDiT: Dual-Condition Diffusion Transformer for Environment-Aware Speech Synthesis**](https://arxiv.org/pdf/2412.19259)
+
+Jaemin Jung*, Junseok Ahn*, Chaeyoung Jung, __Tan Dat Nguyen__, Youngjoon Jang, Joon Son Chung.
+
+- Combines diffusion and transformer models to incorporate environmental cues into speech synthesis.
+- Additional demos will be released soon.
+
+<div class="paper-links">
+  <span class="btn disabled" role="button" aria-disabled="true">Demo coming soon</span>
+  <a class="btn btn--info" href="https://arxiv.org/pdf/2412.19259" target="_blank" rel="noopener" aria-label="View paper" title="View paper"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
+</div>
+
+</div>
+</div>
+
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">FICC 2022</div><img src='images/500x300.png' alt="Placeholder cover for instance-based transfer learning" width="100%"></div></div>
+<div class='paper-box-text' markdown="1">
+
+[**Instance-Based Transfer Learning Approach for Vietnamese Speech Synthesis with Very Low Resource**](https://link.springer.com/chapter/10.1007/978-3-030-98015-3_10)
+
+Tuong Q. Lam, Dung D. Nguyen, __Dat T. Nguyen__, Han K. Lam, Thuc H. Cai, Suong N. Hoang, Hao D. Do.
+
+- Applies instance-based transfer learning to address low-resource Vietnamese speech synthesis settings.
+- Supplementary materials are being curated.
+
+<div class="paper-links">
+  <span class="btn disabled" role="button" aria-disabled="true">Demo coming soon</span>
+  <a class="btn btn--info" href="https://link.springer.com/chapter/10.1007/978-3-030-98015-3_10" target="_blank" rel="noopener" aria-label="View paper" title="View paper"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
+</div>
+
+</div>
+</div>
+
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">RIVF 2021</div><img src='images/500x300.png' alt="Placeholder cover for CNN-based Vietnamese speech synthesis" width="100%"></div></div>
+<div class='paper-box-text' markdown="1">
+
+[**CNN-based Vietnamese Speech Synthesis with Limited Dataset**]()
+
+Lam Quang Tuong, __Nguyen Tan Dat__, Lam Kha Han, Do Duc Hao.
+
+- Early exploration of convolutional architectures for Vietnamese speech synthesis under data constraints.
+- Publication details will be updated soon.
+
+<div class="paper-links">
+  <span class="btn disabled" role="button" aria-disabled="true">Demo coming soon</span>
+  <span class="btn btn--info disabled" role="button" aria-disabled="true"><i class="ai ai-arxiv" aria-hidden="true"></i></span>
+</div>
+
+</div>
+</div>
+
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">RIVF 2021</div><img src='images/500x300.png' alt="Placeholder cover for Instanced-based Transfer Learning" width="100%"></div></div>
+<div class='paper-box-text' markdown="1">
+
+[**Instanced-based Transfer Learning for Vietnamese Speech Synthesis**]()
+
+Lam Quang Tuong, __Nguyen Tan Dat__, Do Duc Hao.
+
+- Studies transfer learning strategies tailored to Vietnamese speech synthesis tasks.
+- Full paper and demos will be provided later.
+
+<div class="paper-links">
+  <span class="btn disabled" role="button" aria-disabled="true">Demo coming soon</span>
+  <span class="btn btn--info disabled" role="button" aria-disabled="true"><i class="ai ai-arxiv" aria-hidden="true"></i></span>
+</div>
+
+</div>
+</div>


### PR DESCRIPTION
## Summary
- add an academic resume link to the author profile sidebar
- merge the publications content into a single section and convert the former list entries into card-style layouts with placeholders
- add the new speech papers and swap paper/code buttons to use icons instead of text

## Testing
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68d6649a320483208487a3511de90d42