### PR TITLE
Update publication listings with PDF icons and uniform thumbnails

### DIFF
--- a/_pages/includes/pub.md
+++ b/_pages/includes/pub.md
@@ -9,12 +9,9 @@
 
 __Tan Dat Nguyen__, Jaehun Kim, Ji-Hoon Kim, Shukjae Choi, Youshin Lim, Joon Son Chung.
 
-- Introduces a joint structured pruning and adaptive distillation pipeline to accelerate LLM-based text-to-speech systems.
-- Delivers efficient speech synthesis while preserving naturalness through carefully aligned student-teacher objectives.
-
 <div class="paper-links">
   <a class="btn" href="https://mm.kaist.ac.kr/projects/SPADE/" target="_blank" rel="noopener">Demo page</a>
-  <a class="btn btn--info" href="https://arxiv.org/abs/2509.20802v1" target="_blank" rel="noopener" aria-label="View paper on arXiv" title="View paper on arXiv"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
+  <a class="btn btn--info" href="https://arxiv.org/abs/2509.20802v1" target="_blank" rel="noopener" aria-label="View PDF" title="View PDF"><i class="fas fa-file-pdf" aria-hidden="true"></i></a>
 </div>
 
 </div>
@@ -27,12 +24,9 @@ __Tan Dat Nguyen__, Jaehun Kim, Ji-Hoon Kim, Shukjae Choi, Youshin Lim, Joon Son
 
 The Hieu Pham*, __Tan Dat Nguyen__*, Phuong Thanh Tran, Joon Son Chung, Duc Dung Nguyen.
 
-- Presents a masked generative enhancement model that progressively restores high-quality speech from noisy inputs.
-- Uses a coarse-to-fine generation strategy to improve intelligibility while maintaining computational efficiency.
-
 <div class="paper-links">
   <a class="btn" href="https://hieugiaosu.github.io/MAGE/" target="_blank" rel="noopener">Live Demo</a>
-  <a class="btn btn--info" href="https://openreview.net/pdf?id=ZEPSOsi63p" target="_blank" rel="noopener" aria-label="View paper" title="View paper"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
+  <a class="btn btn--info" href="https://openreview.net/pdf?id=ZEPSOsi63p" target="_blank" rel="noopener" aria-label="View PDF" title="View PDF"><i class="fas fa-file-pdf" aria-hidden="true"></i></a>
 </div>
 
 </div>
@@ -45,17 +39,13 @@ The Hieu Pham*, __Tan Dat Nguyen__*, Phuong Thanh Tran, Joon Son Chung, Duc Dung
 
 The Hieu Pham, __Nguyen Tan Dat__, Phuong Thanh Tran, Duc Dung Nguyen.
 
-- Explores a language-agnostic speaker extraction system capable of zero-shot transfer to low-resource languages.
-- Demonstrates strong robustness across multilingual benchmarks without language-specific tuning.
-
 <div class="paper-links">
   <a class="btn" href="https://anonymous.4open.science/w/WHYV/" target="_blank" rel="noopener">Live Demo</a>
-  <a class="btn btn--info" href="https://openreview.net/pdf?id=ZEPSOsi63p" target="_blank" rel="noopener" aria-label="View paper" title="View paper"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
+  <a class="btn btn--info" href="https://openreview.net/pdf?id=ZEPSOsi63p" target="_blank" rel="noopener" aria-label="View PDF" title="View PDF"><i class="fas fa-file-pdf" aria-hidden="true"></i></a>
 </div>
 
 </div>
 </div>
-
 
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">ICASSP 2025</div><img src='images/accelerate.png' alt="Accelerating codec-based speech synthesis illustration" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
@@ -64,12 +54,9 @@ The Hieu Pham, __Nguyen Tan Dat__, Phuong Thanh Tran, Duc Dung Nguyen.
 
 __Tan Dat Nguyen__ , [Ji-Hoon Kim](https://sites.google.com/view/jhoonkim/), [Jeongsoo Choi](https://choijeongsoo.github.io/), Shukjae Choi, Jinseok Park, Younglo Lee, [Joon Son Chung+](https://mmai.io/joon/)
 
-- Proposes a method to accelerate codec-based speech synthesis by predicting multiple tokens per step and optimizing token selection with a Viterbi-based speculative decoding technique.
-- Achieves a 4-5x reduction in synthesis time with minimal or improved speech quality.
-
 <div class="paper-links">
   <a class="btn" href="https://mm.kaist.ac.kr/projects/mtp/" target="_blank" rel="noopener">Demo page</a>
-  <a class="btn btn--info" href="https://arxiv.org/abs/2410.13839" target="_blank" rel="noopener" aria-label="View paper on arXiv" title="View paper on arXiv"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
+  <a class="btn btn--info" href="https://arxiv.org/abs/2410.13839" target="_blank" rel="noopener" aria-label="View PDF" title="View PDF"><i class="fas fa-file-pdf" aria-hidden="true"></i></a>
 </div>
 
 </div>
@@ -82,12 +69,9 @@ __Tan Dat Nguyen__ , [Ji-Hoon Kim](https://sites.google.com/view/jhoonkim/), [Je
 
 Jaehun Kim, Ji-Hoon Kim, Yeunju Choi, __Tan Dat Nguyen__, Seongkyu Mun, Joon Son Chung.
 
-- Investigates adaptive learning strategies for high-fidelity voice conversion in cross-speaker scenarios.
-- Extended project assets are under preparation.
-
 <div class="paper-links">
   <span class="btn disabled" role="button" aria-disabled="true">Demo coming soon</span>
-  <a class="btn btn--info" href="https://arxiv.org/abs/2501.01347" target="_blank" rel="noopener" aria-label="View paper on arXiv" title="View paper on arXiv"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
+  <a class="btn btn--info" href="https://arxiv.org/abs/2501.01347" target="_blank" rel="noopener" aria-label="View PDF" title="View PDF"><i class="fas fa-file-pdf" aria-hidden="true"></i></a>
 </div>
 
 </div>
@@ -100,12 +84,9 @@ Jaehun Kim, Ji-Hoon Kim, Yeunju Choi, __Tan Dat Nguyen__, Seongkyu Mun, Joon Son
 
 Jaemin Jung*, Junseok Ahn*, Chaeyoung Jung, __Tan Dat Nguyen__, Youngjoon Jang, Joon Son Chung.
 
-- Combines diffusion and transformer models to incorporate environmental cues into speech synthesis.
-- Additional demos will be released soon.
-
 <div class="paper-links">
   <a class="btn" href="https://mm.kaist.ac.kr/projects/voicedit/" target="_blank" rel="noopener">Demo page</a>
-  <a class="btn btn--info" href="https://arxiv.org/abs/2412.19259" target="_blank" rel="noopener" aria-label="View paper" title="View paper"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
+  <a class="btn btn--info" href="https://arxiv.org/abs/2412.19259" target="_blank" rel="noopener" aria-label="View PDF" title="View PDF"><i class="fas fa-file-pdf" aria-hidden="true"></i></a>
 </div>
 
 </div>
@@ -118,12 +99,9 @@ Jaemin Jung*, Junseok Ahn*, Chaeyoung Jung, __Tan Dat Nguyen__, Youngjoon Jang, 
 
 __Tan Dat Nguyen__* , [Ji-Hoon Kim](https://sites.google.com/view/jhoonkim/)*, [Youngjoon Jang](https://art-jang.github.io/), [Jaehun Kim](https://smokedindia.notion.site/Jaehun-Kim-5006f1fc98004817885325241723f1e3?pvs=74), [Joon Son Chung+](https://mmai.io/joon/) (<font color="red"> Oral Presentation </font>)
 
-- We employ discrete wavelet transform that helps FreGrad to operate on a simple and concise feature space.
-- We design a frequency-aware dilated convolution and introduce a bag of tricks that boosts the generation quality of the proposed model.
-
 <div class="paper-links">
   <a class="btn" href="https://mm.kaist.ac.kr/projects/FreGrad/" target="_blank" rel="noopener">Demo page</a>
-  <a class="btn btn--info" href="https://arxiv.org/abs/2401.10032" target="_blank" rel="noopener" aria-label="View paper on arXiv" title="View paper on arXiv"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
+  <a class="btn btn--info" href="https://arxiv.org/abs/2401.10032" target="_blank" rel="noopener" aria-label="View PDF" title="View PDF"><i class="fas fa-file-pdf" aria-hidden="true"></i></a>
   <a class="btn btn--success" href="https://github.com/kaistmm/fregrad" target="_blank" rel="noopener" aria-label="View source on GitHub" title="View source on GitHub"><i class="fab fa-github" aria-hidden="true"></i></a>
 </div>
 
@@ -137,12 +115,9 @@ __Tan Dat Nguyen__* , [Ji-Hoon Kim](https://sites.google.com/view/jhoonkim/)*, [
 
 The Hieu Pham, __Nguyen Tan Dat__, Phuong Thanh Tran, Duc Dung Nguyen.
 
-- Proposes an adaptive extraction pipeline that personalizes target voice retrieval across languages.
-- Highlights a versatile framework with strong zero-shot generalization backed by comprehensive ablations.
-
 <div class="paper-links">
   <a class="btn" href="https://anonymous.4open.science/w/WHYV/" target="_blank" rel="noopener">Live Demo</a>
-  <a class="btn btn--info" href="https://arxiv.org/abs/2410.00527v1" target="_blank" rel="noopener" aria-label="View paper on arXiv" title="View paper on arXiv"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
+  <a class="btn btn--info" href="https://arxiv.org/abs/2410.00527v1" target="_blank" rel="noopener" aria-label="View PDF" title="View PDF"><i class="fas fa-file-pdf" aria-hidden="true"></i></a>
 </div>
 
 </div>
@@ -155,12 +130,9 @@ The Hieu Pham, __Nguyen Tan Dat__, Phuong Thanh Tran, Duc Dung Nguyen.
 
 __Nguyen Tan Dat__, Lam Quang Tuong, Nguyen Duc Dung
 
-- We propose to use CLUB to minimize the mutual information between content embedding and style embedding.
-- Our work well-perform on zero-shot scenerio even when using skew ASR dataset
-
 <div class="paper-links">
   <a class="btn" href="https://signofthefour.github.io/calib-stylespeech-demo/" target="_blank" rel="noopener">Demo page</a>
-  <a class="btn btn--info" href="https://link.springer.com/chapter/10.1007/978-3-030-97610-1_6" target="_blank" rel="noopener" aria-label="View paper" title="View paper"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
+  <a class="btn btn--info" href="https://link.springer.com/chapter/10.1007/978-3-030-97610-1_6" target="_blank" rel="noopener" aria-label="View PDF" title="View PDF"><i class="fas fa-file-pdf" aria-hidden="true"></i></a>
 </div>
 
 </div>
@@ -173,16 +145,13 @@ __Nguyen Tan Dat__, Lam Quang Tuong, Nguyen Duc Dung
 
 __Tan Dat Nguyen__, Quang Tuong Lam, Duc Hao Do, Huu Thuc Cai, Hoang Suong Nguyen, Thanh Hung Vo, Duc Dung Nguyen.
 
-- We apply phonetic-based transfer learning approach to create Bahnar-Kriem (very low resource language) TTS model.
-
 <div class="paper-links">
   <a class="btn" href="https://signofthefour.github.io/bahnar_demo/" target="_blank" rel="noopener">Demo page</a>
-  <a class="btn btn--info" href="https://ieeexplore.ieee.org/document/10013451" target="_blank" rel="noopener" aria-label="View paper" title="View paper"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
+  <a class="btn btn--info" href="https://ieeexplore.ieee.org/document/10013451" target="_blank" rel="noopener" aria-label="View PDF" title="View PDF"><i class="fas fa-file-pdf" aria-hidden="true"></i></a>
 </div>
 
 </div>
 </div>
-
 
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">FICC 2022</div><img src='images/FICC2022.png' alt="Placeholder cover for instance-based transfer learning" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
@@ -191,9 +160,8 @@ __Tan Dat Nguyen__, Quang Tuong Lam, Duc Hao Do, Huu Thuc Cai, Hoang Suong Nguye
 
 Tuong Q. Lam, Dung D. Nguyen, __Dat T. Nguyen__, Han K. Lam, Thuc H. Cai, Suong N. Hoang, Hao D. Do.
 
-
 <div class="paper-links">
-  <a class="btn btn--info" href="https://link.springer.com/chapter/10.1007/978-3-030-98015-3_10" target="_blank" rel="noopener" aria-label="View paper" title="View paper"><i class="ai ai-arxiv" aria-hidden="true"></i></a>
+  <a class="btn btn--info" href="https://link.springer.com/chapter/10.1007/978-3-030-98015-3_10" target="_blank" rel="noopener" aria-label="View PDF" title="View PDF"><i class="fas fa-file-pdf" aria-hidden="true"></i></a>
 </div>
 
 </div>
@@ -205,7 +173,6 @@ Tuong Q. Lam, Dung D. Nguyen, __Dat T. Nguyen__, Han K. Lam, Thuc H. Cai, Suong 
 [**CNN-based Vietnamese Speech Synthesis with Limited Dataset**]()
 
 Lam Quang Tuong, __Nguyen Tan Dat__, Lam Kha Han, Do Duc Hao.
-
 
 </div>
 </div>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -56,7 +56,9 @@
         width: 100%;
         order: 2;
         img {
-            max-width: 400px;
+            width: 100%;
+            max-width: 240px;
+            height: 160px;
             box-shadow: 3px 3px 6px #888;
             object-fit: cover;
             border-radius: 8px;


### PR DESCRIPTION
## Summary
- replace the arXiv button icons with PDF file icons and update the related accessibility text
- remove the descriptive bullet lists from each publication card to keep the listings concise
- constrain publication thumbnails to a consistent, smaller size for easier scanning

## Testing
- ⚠️ `bundle install` *(fails with Rubygems 403, preventing local Jekyll server startup)*

------
https://chatgpt.com/codex/tasks/task_e_68d66cd58e1883209b6bbfd6bf4ab3c2