### PR TITLE
Add citation summary card and visitor map

### DIFF
--- a/_includes/fetch_google_scholar_stats.html
+++ b/_includes/fetch_google_scholar_stats.html
@@ -6,8 +6,11 @@
         var gsDataBaseUrl = 'https://raw.githubusercontent.com/{{ site.repository }}/'
         {% endif %}
         $.getJSON(gsDataBaseUrl + "google-scholar-stats/gs_data.json", function (data) {
-            // var totalCitation = data['citedby']
-            // document.getElementById('total_cit').innerHTML = totalCitation;
+            var totalCitation = data['citedby']
+            var totalCitElement = document.getElementById('total_cit');
+            if (totalCitElement) {
+                totalCitElement.innerHTML = totalCitation;
+            }
             var citationEles = document.getElementsByClassName('show_paper_citations')
             Array.prototype.forEach.call(citationEles, element => {
                 var paperId = element.getAttribute('data')

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -11,6 +11,8 @@ redirect_from:
 <span class='anchor' id='about-me'></span>
 {% include_relative includes/intro.md %}
 
+{% include_relative includes/citations.md %}
+
 {% include_relative includes/news.md %}
 
 {% include_relative includes/pub.md %}
@@ -18,5 +20,11 @@ redirect_from:
 {% include_relative includes/honers.md %}
 
 {% include_relative includes/others.md %}
+
+## 🌍 Visitors
+
+<div class="visitor-map" aria-label="Visitor locations">
+<script type="text/javascript" id="clstr_globe" src="//clustrmaps.com/globe.js?d=cYyq_LnJQ6KCqpUnMqGX2-jL4VxsaSO55RKm9birgzc"></script>
+</div>
 
 If you like the template of this homepage, please go to [AcadHomepage ![](https://img.shields.io/github/stars/RayeRen/acad-homepage.github.io?style=social)](https://github.com/RayeRen/acad-homepage.github.io). Thank YiRen for providing a clean yet beautiful template.

--- a/_pages/includes/citations.md
+++ b/_pages/includes/citations.md
@@ -1,0 +1,16 @@
+{% assign total_citations = site.data.google_scholar_stats.citedby %}
+{% assign scholar_url = site.author.googlescholar %}
+
+<div class="scholar-metrics">
+  <div class="scholar-metrics__card">
+    <div class="scholar-metrics__label">Google Scholar</div>
+    <div class="scholar-metrics__count" id="total_cit">{{ total_citations | default: "--" }}</div>
+    <div class="scholar-metrics__description">Total citations across all publications.</div>
+    <div class="scholar-metrics__actions">
+      <a class="btn btn--primary" href="{{ scholar_url }}" target="_blank" rel="noopener">View profile</a>
+    </div>
+    {% if site.data.google_scholar_stats.updated %}
+    <div class="scholar-metrics__meta">Last updated: {{ site.data.google_scholar_stats.updated }}</div>
+    {% endif %}
+  </div>
+</div>

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -148,6 +148,67 @@ $base-border-radius: 20px;
       text-decoration: none;
     }
   }
+
+  .scholar-metrics {
+    margin: 2rem 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+
+    &__card {
+      background-color: var(--secondary-color);
+      border-radius: 16px;
+      padding: 1.5rem;
+      box-shadow: 0 8px 24px rgba(45, 55, 72, 0.12);
+      min-width: 16rem;
+      max-width: 22rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    &__label {
+      font-size: $type-size-6;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--primary-color);
+      opacity: 0.75;
+    }
+
+    &__count {
+      font-family: $global-font-family, 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      font-size: clamp(2rem, 4vw, 2.75rem);
+      font-weight: 700;
+      color: var(--accent-color);
+    }
+
+    &__description {
+      font-size: $type-size-6;
+      color: var(--primary-color);
+      opacity: 0.8;
+    }
+
+    &__actions {
+      margin-top: 0.5rem;
+
+      .btn {
+        text-decoration: none;
+      }
+    }
+
+    &__meta {
+      font-size: $type-size-7;
+      color: var(--primary-color);
+      opacity: 0.65;
+    }
+  }
+
+  .visitor-map {
+    margin: 2.5rem 0;
+    display: flex;
+    justify-content: center;
+    filter: drop-shadow(0 8px 24px rgba(45, 55, 72, 0.15));
+  }
 }
 
 .page__hero {


### PR DESCRIPTION
## Summary
- add a Google Scholar citation highlight card to the homepage and style it for clarity
- enable the existing fetch script to populate the total citation count dynamically
- embed the provided ClustrMaps globe at the bottom of the page to show visitor locations

## Testing
- bundle exec jekyll build *(fails: jekyll gem not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d90bdcaaac83209dd09c9f838aad33