### PR TITLE
Remove citation count from homepage

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -11,8 +11,6 @@ redirect_from:
 <span class='anchor' id='about-me'></span>
 {% include_relative includes/intro.md %}
 
-{% include_relative includes/citations.md %}
-
 {% include_relative includes/news.md %}
 
 {% include_relative includes/pub.md %}


### PR DESCRIPTION
## Summary
- stop including the citation metrics partial on the landing page so the total citation count no longer appears

## Testing
- not run (bundle install failed with HTTP 403 when trying to fetch gems)


------
https://chatgpt.com/codex/tasks/task_e_68d92c505cc883209d1ea29d417f61e1