### PR TITLE
Add publication prefixes and refine paper cards

### DIFF
--- a/_pages/includes/pub.md
+++ b/_pages/includes/pub.md
@@ -5,7 +5,7 @@
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">ArXiv 2025</div><img src='images/spade.png' alt="Placeholder cover for SPADE" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
-[**SPADE: Structured Pruning and Adaptive Distillation for Efficient LLM-TTS**](https://arxiv.org/abs/2509.20802v1)
+<span class="paper-prefix">[S.3]</span> [**SPADE: Structured Pruning and Adaptive Distillation for Efficient LLM-TTS**](https://arxiv.org/abs/2509.20802v1)
 
 __Tan Dat Nguyen__, Jaehun Kim, Ji-Hoon Kim, Shukjae Choi, Youshin Lim, Joon Son Chung.
 
@@ -20,7 +20,7 @@ __Tan Dat Nguyen__, Jaehun Kim, Ji-Hoon Kim, Shukjae Choi, Youshin Lim, Joon Son
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">ArXiv 2025</div><img src='images/mage.png' alt="Placeholder cover for MAGE" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
-[**MAGE: A Coarse-to-Fine Speech Enhancer with Masked Generative Model**](https://openreview.net/pdf?id=ZEPSOsi63p)
+<span class="paper-prefix">[S.2]</span> [**MAGE: A Coarse-to-Fine Speech Enhancer with Masked Generative Model**](https://openreview.net/pdf?id=ZEPSOsi63p)
 
 The Hieu Pham*, __Tan Dat Nguyen__*, Phuong Thanh Tran, Joon Son Chung, Duc Dung Nguyen.
 
@@ -35,7 +35,7 @@ The Hieu Pham*, __Tan Dat Nguyen__*, Phuong Thanh Tran, Joon Son Chung, Duc Dung
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">OpenReview 2024</div><img src='images/whyv2.png' alt="Placeholder cover for Language-Agnostic Target Speaker Extraction" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
-[**Language-Agnostic Target Speaker Extraction with Zero-Shot Generalization to Low-Resource Languages**](https://openreview.net/pdf?id=ZEPSOsi63p)
+<span class="paper-prefix">[S.1]</span> [**Language-Agnostic Target Speaker Extraction with Zero-Shot Generalization to Low-Resource Languages**](https://openreview.net/pdf?id=ZEPSOsi63p)
 
 The Hieu Pham, __Nguyen Tan Dat__, Phuong Thanh Tran, Duc Dung Nguyen.
 
@@ -50,7 +50,7 @@ The Hieu Pham, __Nguyen Tan Dat__, Phuong Thanh Tran, Duc Dung Nguyen.
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">ICASSP 2025</div><img src='images/accelerate.png' alt="Accelerating codec-based speech synthesis illustration" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
-[**Accelerating Codec-based Speech Synthesis with Multi-Token Prediction and Speculative Decoding**](https://arxiv.org/abs/2410.13839)
+<span class="paper-prefix">[C.7]</span> [**Accelerating Codec-based Speech Synthesis with Multi-Token Prediction and Speculative Decoding**](https://arxiv.org/abs/2410.13839)
 
 __Tan Dat Nguyen__ , [Ji-Hoon Kim](https://sites.google.com/view/jhoonkim/), [Jeongsoo Choi](https://choijeongsoo.github.io/), Shukjae Choi, Jinseok Park, Younglo Lee, [Joon Son Chung+](https://mmai.io/joon/)
 
@@ -65,7 +65,7 @@ __Tan Dat Nguyen__ , [Ji-Hoon Kim](https://sites.google.com/view/jhoonkim/), [Je
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">ICASSP 2025</div><img src='images/adaptvc.png' alt="Placeholder cover for AdaptVC" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
-[**AdaptVC: High Quality Voice Conversion with Adaptive Learning**](https://arxiv.org/abs/2501.01347)
+<span class="paper-prefix">[C.6]</span> [**AdaptVC: High Quality Voice Conversion with Adaptive Learning**](https://arxiv.org/abs/2501.01347)
 
 Jaehun Kim, Ji-Hoon Kim, Yeunju Choi, __Tan Dat Nguyen__, Seongkyu Mun, Joon Son Chung.
 
@@ -80,7 +80,7 @@ Jaehun Kim, Ji-Hoon Kim, Yeunju Choi, __Tan Dat Nguyen__, Seongkyu Mun, Joon Son
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">ICASSP 2025</div><img src='images/voicedit.png' alt="Placeholder cover for VoiceDiT" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
-[**VoiceDiT: Dual-Condition Diffusion Transformer for Environment-Aware Speech Synthesis**](https://arxiv.org/pdf/2412.19259)
+<span class="paper-prefix">[C.5]</span> [**VoiceDiT: Dual-Condition Diffusion Transformer for Environment-Aware Speech Synthesis**](https://arxiv.org/pdf/2412.19259)
 
 Jaemin Jung*, Junseok Ahn*, Chaeyoung Jung, __Tan Dat Nguyen__, Youngjoon Jang, Joon Son Chung.
 
@@ -95,7 +95,7 @@ Jaemin Jung*, Junseok Ahn*, Chaeyoung Jung, __Tan Dat Nguyen__, Youngjoon Jang, 
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">ICASSP 2024</div><img src='images/500x300.png' alt="FreGrad illustration placeholder" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
-[**FreGrad: Lightweight and fast frequency-aware diffusion vocoder**](https://arxiv.org/abs/2401.10032)
+<span class="paper-prefix">[C.4]</span> [**FreGrad: Lightweight and fast frequency-aware diffusion vocoder**](https://arxiv.org/abs/2401.10032)
 
 __Tan Dat Nguyen__* , [Ji-Hoon Kim](https://sites.google.com/view/jhoonkim/)*, [Youngjoon Jang](https://art-jang.github.io/), [Jaehun Kim](https://smokedindia.notion.site/Jaehun-Kim-5006f1fc98004817885325241723f1e3?pvs=74), [Joon Son Chung+](https://mmai.io/joon/) (<font color="red"> Oral Presentation </font>)
 
@@ -111,7 +111,7 @@ __Tan Dat Nguyen__* , [Ji-Hoon Kim](https://sites.google.com/view/jhoonkim/)*, [
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">Preprint 2024</div><img src='images/whyv.png' alt="Placeholder cover for Wanna Hear Your Voice" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
-[**Wanna Hear Your Voice: Adaptive, Effective, and Language-Agnostic Approach in Voice Extraction**](https://arxiv.org/abs/2410.00527v1)
+<span class="paper-prefix">[A.1]</span> [**Wanna Hear Your Voice: Adaptive, Effective, and Language-Agnostic Approach in Voice Extraction**](https://arxiv.org/abs/2410.00527v1)
 
 The Hieu Pham, __Nguyen Tan Dat__, Phuong Thanh Tran, Duc Dung Nguyen.
 
@@ -126,7 +126,7 @@ The Hieu Pham, __Nguyen Tan Dat__, Phuong Thanh Tran, Duc Dung Nguyen.
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">ICABDE 2021</div><img src='images/CalibStyelSpeech.png' alt="Calib-StyleSpeech illustration" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
-[**Calib-StyleSpeech: A Zero-shot Approach In Voice Cloning Of High Adaptive Text To Speech System With Imbalanced Dataset**](https://link.springer.com/chapter/10.1007/978-3-030-97610-1_6) (<font color="red"> Oral Presentation </font>)
+<span class="paper-prefix">[C.2]</span> [**Calib-StyleSpeech: A Zero-shot Approach In Voice Cloning Of High Adaptive Text To Speech System With Imbalanced Dataset**](https://link.springer.com/chapter/10.1007/978-3-030-97610-1_6) (<font color="red"> Oral Presentation </font>)
 
 __Nguyen Tan Dat__, Lam Quang Tuong, Nguyen Duc Dung
 
@@ -141,7 +141,7 @@ __Nguyen Tan Dat__, Lam Quang Tuong, Nguyen Duc Dung
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">NAFOSTED 2021</div><img src='images/bahnar.png' alt="Bahnar TTS illustration" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
-[*A Linguistic-based Transfer Learning Approach for Low-resource Bahnar Text-to-Speech*](https://ieeexplore.ieee.org/document/10013451) (<font color="red"> Oral Presentation </font>)
+<span class="paper-prefix">[C.3]</span> [*A Linguistic-based Transfer Learning Approach for Low-resource Bahnar Text-to-Speech*](https://ieeexplore.ieee.org/document/10013451) (<font color="red"> Oral Presentation </font>)
 
 __Tan Dat Nguyen__, Quang Tuong Lam, Duc Hao Do, Huu Thuc Cai, Hoang Suong Nguyen, Thanh Hung Vo, Duc Dung Nguyen.
 
@@ -156,7 +156,7 @@ __Tan Dat Nguyen__, Quang Tuong Lam, Duc Hao Do, Huu Thuc Cai, Hoang Suong Nguye
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">FICC 2022</div><img src='images/FICC2022.png' alt="Placeholder cover for instance-based transfer learning" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
-[**Instance-Based Transfer Learning Approach for Vietnamese Speech Synthesis with Very Low Resource**](https://link.springer.com/chapter/10.1007/978-3-030-98015-3_10)
+<span class="paper-prefix">[C.1]</span> [**Instance-Based Transfer Learning Approach for Vietnamese Speech Synthesis with Very Low Resource**](https://link.springer.com/chapter/10.1007/978-3-030-98015-3_10)
 
 Tuong Q. Lam, Dung D. Nguyen, __Dat T. Nguyen__, Han K. Lam, Thuc H. Cai, Suong N. Hoang, Hao D. Do.
 
@@ -170,7 +170,7 @@ Tuong Q. Lam, Dung D. Nguyen, __Dat T. Nguyen__, Han K. Lam, Thuc H. Cai, Suong 
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">RIVF 2021</div><img src='images/blank.png' alt="Placeholder cover for CNN-based Vietnamese speech synthesis" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
-[**CNN-based Vietnamese Speech Synthesis with Limited Dataset**]()
+<span class="paper-prefix">[C]</span> [**CNN-based Vietnamese Speech Synthesis with Limited Dataset**]()
 
 Lam Quang Tuong, __Nguyen Tan Dat__, Lam Kha Han, Do Duc Hao.
 
@@ -180,7 +180,7 @@ Lam Quang Tuong, __Nguyen Tan Dat__, Lam Kha Han, Do Duc Hao.
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">RIVF 2021</div><img src='images/blank.png' alt="" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
-[**Instanced-based Transfer Learning for Vietnamese Speech Synthesis**]()
+<span class="paper-prefix">[C]</span> [**Instanced-based Transfer Learning for Vietnamese Speech Synthesis**]()
 
 Lam Quang Tuong, __Nguyen Tan Dat__, Do Duc Hao.
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -55,10 +55,11 @@
         display: flex;
         width: 100%;
         order: 2;
+        margin-bottom: 1em;
         img {
-            width: 100%;
-            max-width: 240px;
-            height: 160px;
+            width: 160px;
+            height: 120px;
+            max-width: 100%;
             box-shadow: 3px 3px 6px #888;
             object-fit: cover;
             border-radius: 8px;
@@ -73,15 +74,18 @@
     @include breakpoint($medium) {
         .paper-box-image{
             justify-content: left;
-            min-width: 200px;
-            max-width: 40%;
+            min-width: 160px;
+            max-width: 160px;
+            margin-bottom: 0;
+            margin-right: 1.25em;
             order: 1;
         }
-        
+
         .paper-box-text{
             justify-content: left;
-            padding-left: 2em;
-            max-width: 60%;
+            padding-left: 0;
+            flex: 1 1 0;
+            max-width: 100%;
             order: 2;
         }
 
@@ -110,3 +114,12 @@ h1:before, .anchor:before {
     background-color: $primary-color;
     font-size: .8em;
 }
+
+.paper-prefix {
+    display: inline-block;
+    margin-right: .4em;
+    font-weight: 600;
+    color: $primary-color;
+    white-space: nowrap;
+}
+


### PR DESCRIPTION
## Summary
- add publication-type prefixes to each speech synthesis entry
- tweak paper card layout to standardize image sizing and tighten spacing

## Testing
- not run (environment lacks Bundler access)


------
https://chatgpt.com/codex/tasks/task_e_68d9e2eabdcc8320862b9ff82a82aa6b