### PR TITLE
Add dark mode toggle and work experience section

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -1,5 +1,23 @@
 <div class="masthead">
   <div class="masthead__inner-wrap">
+    <div class="masthead__controls">
+      <button class="theme-toggle" type="button" aria-label="Toggle light and dark mode" aria-pressed="false">
+        <svg class="theme-toggle__icon theme-toggle__icon--sun" viewBox="0 0 24 24" role="presentation" aria-hidden="true">
+          <circle cx="12" cy="12" r="5"></circle>
+          <line x1="12" y1="1" x2="12" y2="4"></line>
+          <line x1="12" y1="20" x2="12" y2="23"></line>
+          <line x1="4.22" y1="4.22" x2="6.34" y2="6.34"></line>
+          <line x1="17.66" y1="17.66" x2="19.78" y2="19.78"></line>
+          <line x1="1" y1="12" x2="4" y2="12"></line>
+          <line x1="20" y1="12" x2="23" y2="12"></line>
+          <line x1="4.22" y1="19.78" x2="6.34" y2="17.66"></line>
+          <line x1="17.66" y1="6.34" x2="19.78" y2="4.22"></line>
+        </svg>
+        <svg class="theme-toggle__icon theme-toggle__icon--moon" viewBox="0 0 24 24" role="presentation" aria-hidden="true">
+          <path d="M21 12.79A9 9 0 0 1 11.21 3 7 7 0 1 0 21 12.79z"></path>
+        </svg>
+      </button>
+    </div>
     <div class="masthead__menu">
       <nav id="site-nav" class="greedy-nav">
         <button><div class="navicon"></div></button>
@@ -16,9 +34,94 @@
 </div>
 
 <script>
-  document.querySelector('.greedy-nav button').addEventListener('click', function() {
-    this.classList.toggle('active');
-    document.querySelector('.visible-links').classList.toggle('active');
-    document.querySelector('.hidden-links').classList.toggle('active');
-  });
+  (function() {
+    var greedyToggle = document.querySelector('.greedy-nav button');
+    var visibleLinks = document.querySelector('.greedy-nav .visible-links');
+    var hiddenLinks = document.querySelector('.greedy-nav .hidden-links');
+
+    if (greedyToggle && visibleLinks && hiddenLinks) {
+      greedyToggle.addEventListener('click', function() {
+        this.classList.toggle('active');
+        visibleLinks.classList.toggle('active');
+        hiddenLinks.classList.toggle('active');
+      });
+    }
+
+    var toggleButton = document.querySelector('.theme-toggle');
+    if (!toggleButton) {
+      return;
+    }
+
+    var storageKey = 'preferred-color-scheme';
+    var root = document.documentElement;
+    var themeMeta = document.querySelector('meta[name="theme-color"]');
+
+    function setAriaPressed(isDark) {
+      toggleButton.setAttribute('aria-pressed', isDark ? 'true' : 'false');
+    }
+
+    function updateMetaTheme(theme) {
+      if (themeMeta) {
+        themeMeta.setAttribute('content', theme === 'dark' ? '#2D3748' : '#ffffff');
+      }
+    }
+
+    function applyTheme(theme, persist) {
+      var normalizedTheme = theme === 'dark' ? 'dark' : 'light';
+      root.classList.remove('theme-dark', 'theme-light');
+      root.classList.add('theme-' + normalizedTheme);
+      root.setAttribute('data-theme', normalizedTheme);
+      setAriaPressed(normalizedTheme === 'dark');
+      updateMetaTheme(normalizedTheme);
+
+      if (persist) {
+        try {
+          window.localStorage.setItem(storageKey, normalizedTheme);
+        } catch (e) {
+          /* Ignore write errors */
+        }
+      }
+    }
+
+    function getStoredPreference() {
+      try {
+        return window.localStorage.getItem(storageKey);
+      } catch (e) {
+        return null;
+      }
+    }
+
+    function getSystemPreference() {
+      return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+
+    var storedPreference = getStoredPreference();
+
+    if (storedPreference === 'dark' || storedPreference === 'light') {
+      applyTheme(storedPreference, false);
+    } else {
+      applyTheme(getSystemPreference(), false);
+    }
+
+    toggleButton.addEventListener('click', function() {
+      var isDark = root.classList.contains('theme-dark');
+      applyTheme(isDark ? 'light' : 'dark', true);
+    });
+
+    if (window.matchMedia) {
+      var mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+      var systemPreferenceListener = function(event) {
+        var persisted = getStoredPreference();
+        if (persisted !== 'dark' && persisted !== 'light') {
+          applyTheme(event.matches ? 'dark' : 'light', false);
+        }
+      };
+
+      if (typeof mediaQuery.addEventListener === 'function') {
+        mediaQuery.addEventListener('change', systemPreferenceListener);
+      } else if (typeof mediaQuery.addListener === 'function') {
+        mediaQuery.addListener(systemPreferenceListener);
+      }
+    }
+  })();
 </script>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -15,6 +15,8 @@ redirect_from:
 
 {% include_relative includes/pub.md %}
 
+{% include_relative includes/work.md %}
+
 {% include_relative includes/honers.md %}
 
 {% include_relative includes/others.md %}

--- a/_pages/includes/pub.md
+++ b/_pages/includes/pub.md
@@ -2,6 +2,8 @@
 
 ## 🎙 Speech Synthesis
 
+_Note: C=CONFERENCE, J=JOURNAL, P=PATENT, S=IN SUBMISSION, A=PREPRINT, *=EQUAL CONTRIBUTION_
+
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">ArXiv 2025</div><img src='images/spade.png' alt="Placeholder cover for SPADE" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
@@ -70,7 +72,7 @@ __Tan Dat Nguyen__ , [Ji-Hoon Kim](https://sites.google.com/view/jhoonkim/), [Je
 Jaehun Kim, Ji-Hoon Kim, Yeunju Choi, __Tan Dat Nguyen__, Seongkyu Mun, Joon Son Chung.
 
 <div class="paper-links">
-  <span class="btn disabled" role="button" aria-disabled="true">Demo coming soon</span>
+  <a class="btn" href="https://mm.kaist.ac.kr/projects/AdaptVC/" target="_blank" rel="noopener">Demo page</a>
   <a class="btn btn--info" href="https://arxiv.org/abs/2501.01347" target="_blank" rel="noopener" aria-label="View PDF" title="View PDF"><i class="fas fa-file-pdf" aria-hidden="true"></i></a>
 </div>
 
@@ -170,7 +172,7 @@ Tuong Q. Lam, Dung D. Nguyen, __Dat T. Nguyen__, Han K. Lam, Thuc H. Cai, Suong 
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">RIVF 2021</div><img src='images/blank.png' alt="Placeholder cover for CNN-based Vietnamese speech synthesis" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
-<span class="paper-prefix">[C]</span> [**CNN-based Vietnamese Speech Synthesis with Limited Dataset**]()
+<span class="paper-prefix">[National conference (Vietnam)]</span> [**CNN-based Vietnamese Speech Synthesis with Limited Dataset**]()
 
 Lam Quang Tuong, __Nguyen Tan Dat__, Lam Kha Han, Do Duc Hao.
 
@@ -180,7 +182,7 @@ Lam Quang Tuong, __Nguyen Tan Dat__, Lam Kha Han, Do Duc Hao.
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">RIVF 2021</div><img src='images/blank.png' alt="" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
-<span class="paper-prefix">[C]</span> [**Instanced-based Transfer Learning for Vietnamese Speech Synthesis**]()
+<span class="paper-prefix">[National conference (Vietnam)]</span> [**Instanced-based Transfer Learning for Vietnamese Speech Synthesis**]()
 
 Lam Quang Tuong, __Nguyen Tan Dat__, Do Duc Hao.
 

--- a/_pages/includes/work.md
+++ b/_pages/includes/work.md
@@ -1,0 +1,3 @@
+## 💼 Work Experience
+
+- **OLLI Technology Corp., Vietnam** — *October 2021 – February 2023*

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -29,6 +29,26 @@ $global-transition: all 0.2s ease-in-out;
   }
 }
 
+:root.theme-light {
+  --primary-color: #2D3748;
+  --secondary-color: #EDF2F7;
+  --accent-color: #4C51BF;
+  --text-color: #2D3748;
+  --border-color: #CBD5E0;
+  --code-background-color: #F7FAFC;
+  --background-color: #FFFFFF;
+}
+
+:root.theme-dark {
+  --primary-color: #E2E8F0;
+  --secondary-color: #2D3748;
+  --accent-color: #7F9CF5;
+  --text-color: #E2E8F0;
+  --border-color: #4A5568;
+  --code-background-color: #2D3748;
+  --background-color: #2D3748;
+}
+
 html {
   /* Sticky footer fix */
   position: relative;
@@ -40,6 +60,7 @@ body {
   margin: 0;
   padding: 0;
   padding-bottom: $base-spacing * 2; /* Adjusted for consistency */
+  background-color: var(--background-color);
   color: var(--text-color);
   font-family: $global-font-family, 'Inter', Arial, sans-serif; /* Added fallbacks */
   line-height: 1.5;

--- a/_sass/_forms.scss
+++ b/_sass/_forms.scss
@@ -24,6 +24,22 @@ $base-border-radius: 8px;
   }
 }
 
+:root.theme-light {
+  --primary-color: #2D3748;
+  --secondary-color: #EDF2F7;
+  --accent-color: #4C51BF;
+  --text-color: #2D3748;
+  --info-color: #3182CE;
+}
+
+:root.theme-dark {
+  --primary-color: #E2E8F0;
+  --secondary-color: #2D3748;
+  --accent-color: #7F9CF5;
+  --text-color: #E2E8F0;
+  --info-color: #90CDF4;
+}
+
 form {
   margin: 0 0 $base-spacing 0;
 

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -5,8 +5,8 @@
 .masthead {
   position: sticky;
   top: 0;
-  background-color: white;
-  border-bottom: 1px solid $border-color;
+  background-color: var(--background-color);
+  border-bottom: 1px solid var(--border-color);
   -webkit-animation: intro 0.3s both;
           animation: intro 0.3s both;
   -webkit-animation-delay: 0.15s;
@@ -18,6 +18,9 @@
     @include clearfix;
     padding: .5em;
     font-family: $sans-serif-narrow;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
 
     @include breakpoint($x-large) {
       max-width: $x-large;
@@ -25,6 +28,7 @@
 
     nav {
       z-index: 10;
+      flex: 1 1 auto;
     }
 
     a {
@@ -33,7 +37,14 @@
   }
 }
 
+.masthead__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .masthead__menu {
+  flex: 1 1 auto;
 
   ul {
     margin: 0;
@@ -59,4 +70,64 @@
     padding-right: 2em;
     font-weight: 700;
   }
+}
+
+.theme-toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background-color: var(--secondary-color);
+  color: var(--primary-color);
+  cursor: pointer;
+  transition: background-color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+  padding: 0;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus {
+  background-color: var(--accent-color);
+  border-color: var(--accent-color);
+  color: #ffffff;
+  box-shadow: 0 0 0 3px rgba(76, 81, 191, 0.2);
+  outline: none;
+}
+
+.theme-toggle__icon {
+  width: 1.4rem;
+  height: 1.4rem;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.5;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.theme-toggle__icon--moon {
+  fill: currentColor;
+  opacity: 0;
+  position: absolute;
+  transform: scale(0.8);
+}
+
+.theme-toggle__icon--sun {
+  opacity: 1;
+}
+
+html.theme-dark .theme-toggle__icon--sun {
+  opacity: 0;
+  transform: scale(0.8);
+}
+
+html.theme-dark .theme-toggle__icon--moon {
+  opacity: 1;
+  transform: scale(1);
+}
+
+html.theme-dark .theme-toggle {
+  background-color: var(--secondary-color);
+  border-color: var(--border-color);
 }

--- a/_sass/_notices.scss
+++ b/_sass/_notices.scss
@@ -41,6 +41,30 @@ $global-transition: all 0.2s ease-in-out;
   }
 }
 
+:root.theme-light {
+  --primary-color: #2D3748;
+  --secondary-color: #EDF2F7;
+  --accent-color: #4C51BF;
+  --text-color: #2D3748;
+  --default-notice-color: #E2E8F0;
+  --info-color: #3182CE;
+  --warning-color: #DD6B20;
+  --success-color: #38A169;
+  --danger-color: #E53E3E;
+}
+
+:root.theme-dark {
+  --primary-color: #E2E8F0;
+  --secondary-color: #2D3748;
+  --accent-color: #7F9CF5;
+  --text-color: #E2E8F0;
+  --default-notice-color: #4A5568;
+  --info-color: #90CDF4;
+  --warning-color: #F6AD55;
+  --success-color: #68D391;
+  --danger-color: #FC8181;
+}
+
 @mixin notice($notice-color) {
   margin: $base-spacing * 2 0;
   padding: $base-spacing;

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -20,6 +20,18 @@ $base-border-radius: 20px;
   }
 }
 
+:root.theme-light {
+  --primary-color: #2D3748;
+  --secondary-color: #EDF2F7;
+  --accent-color: #4C51BF;
+}
+
+:root.theme-dark {
+  --primary-color: #E2E8F0;
+  --secondary-color: #2D3748;
+  --accent-color: #7F9CF5;
+}
+
 #main {
   display: grid;
   grid-template-columns: 2fr 10fr;

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -29,6 +29,24 @@ $sidebar-width: 250px;
   }
 }
 
+:root.theme-light {
+  --primary-color: #2D3748;
+  --secondary-color: #EDF2F7;
+  --accent-color: #4C51BF;
+  --accent-color-dark: #3E4299;
+  --text-color: #2D3748;
+  --border-color: #CBD5E0;
+}
+
+:root.theme-dark {
+  --primary-color: #E2E8F0;
+  --secondary-color: #2D3748;
+  --accent-color: #7F9CF5;
+  --accent-color-dark: #6B89E0;
+  --text-color: #E2E8F0;
+  --border-color: #4A5568;
+}
+
 .sidebar {
   background: var(--secondary-color);
   padding: $base-spacing / 2; /* Reduced for mobile */

--- a/_sass/_tables.scss
+++ b/_sass/_tables.scss
@@ -25,6 +25,22 @@ $global-transition: all 0.2s ease-in-out;
   }
 }
 
+:root.theme-light {
+  --primary-color: #2D3748;
+  --secondary-color: #EDF2F7;
+  --accent-color: #4C51BF;
+  --text-color: #2D3748;
+  --border-color: #CBD5E0;
+}
+
+:root.theme-dark {
+  --primary-color: #E2E8F0;
+  --secondary-color: #2D3748;
+  --accent-color: #7F9CF5;
+  --text-color: #E2E8F0;
+  --border-color: #4A5568;
+}
+
 .table-wrapper {
   overflow-x: auto; /* Enable horizontal scrolling on small screens */
   margin-bottom: $base-spacing;


### PR DESCRIPTION
## Summary
- add a sun and moon theme toggle that persists the user's preference and updates the browser theme color
- update shared SCSS variables so manual theme selection affects base, masthead, and component styling
- introduce a work experience include and surface the OLLI Technology Corp. role on the homepage

## Testing
- not run (jekyll dependencies unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d9e731db608320bcbc96fe1ef0e8ee