### PR TITLE
Stop menu links from opening in a new tab

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,6 +14,3 @@
 <link rel="stylesheet" href="assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
-<head>
-  <base target="_blank">
-</head>


### PR DESCRIPTION
## Summary
- remove the global `<base target="_blank">` tag from the shared head include so in-page menu links open in the same tab

## Testing
- bundle exec jekyll serve --livereload --host 0.0.0.0 --port 4000 *(fails: bundler could not download dependencies due to HTTP 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68da425823488320a70c578cb8c4b518