### PR TITLE
Add ICASSP 2026 news and update MAGE/SPADE badges

### DIFF
--- a/_pages/includes/news.md
+++ b/_pages/includes/news.md
@@ -1,3 +1,4 @@
 # 🔥 News
+- *2025.12*: &nbsp;🎉🎉 Two papers are accepted by ICASSP 2026
 - *2024.12*: &nbsp;🎉🎉 Three papers are accepted by ICASSP 2025
 - *2023.11*: &nbsp;🎉🎉 One paper is accepted by ICASSP 2024

--- a/_pages/includes/pub.md
+++ b/_pages/includes/pub.md
@@ -4,7 +4,7 @@
 
 _Note: C=CONFERENCE, J=JOURNAL, P=PATENT, S=IN SUBMISSION, A=PREPRINT, *=EQUAL CONTRIBUTION_
 
-<div class='paper-box'><div class='paper-box-image'><div><div class="badge">ArXiv 2025</div><img src='images/spade.png' alt="Placeholder cover for SPADE" width="100%"></div></div>
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">ICASSP 2026</div><img src='images/spade.png' alt="Placeholder cover for SPADE" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
 <span class="paper-prefix">[S.3]</span> [**SPADE: Structured Pruning and Adaptive Distillation for Efficient LLM-TTS**](https://arxiv.org/abs/2509.20802v1)
@@ -19,7 +19,7 @@ __Tan Dat Nguyen__, Jaehun Kim, Ji-Hoon Kim, Shukjae Choi, Youshin Lim, Joon Son
 </div>
 </div>
 
-<div class='paper-box'><div class='paper-box-image'><div><div class="badge">ArXiv 2025</div><img src='images/mage.png' alt="Placeholder cover for MAGE" width="100%"></div></div>
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">ICASSP 2026</div><img src='images/mage.png' alt="Placeholder cover for MAGE" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
 <span class="paper-prefix">[S.2]</span> [**MAGE: A Coarse-to-Fine Speech Enhancer with Masked Generative Model**](https://openreview.net/pdf?id=ZEPSOsi63p)


### PR DESCRIPTION
### Motivation
- Announce the recent acceptances to ICASSP 2026 and reflect the updated conference placement for two projects in the publications list.

### Description
- Added a news entry in ` _pages/includes/news.md` announcing two papers accepted by ICASSP 2026. 
- Updated the publication badges for `SPADE` and `MAGE` from "ArXiv 2025" to "ICASSP 2026" in ` _pages/includes/pub.md`.
- Changes are committed to the branch.

### Testing
- Attempted to run the site locally with `bundle exec jekyll serve --livereload --host 0.0.0.0 --port 4000`, which failed because the `jekyll` executable is not available in the environment. 
- No other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ccb2c30848320b841ed5879158236)